### PR TITLE
build: updated glassfish-resources.xml to repair payara/Payara issue #4864

### DIFF
--- a/fmdb/FMDB-ear/src/main/application/META-INF/glassfish-resources.xml
+++ b/fmdb/FMDB-ear/src/main/application/META-INF/glassfish-resources.xml
@@ -3,17 +3,19 @@
 <resources>
 
     <jdbc-connection-pool is-isolation-level-guaranteed="false" datasource-classname="org.postgresql.ds.PGSimpleDataSource" name="FMDB-DB-Internal_Proxy_user" sql-trace-listeners="" res-type="javax.sql.DataSource">
-        <property name="URL" value="${ENV=JDBC_SETTING}"></property>
-        <property name="Password" value="${ENV=PG_PASSWORD}"></property>
-		<property name="driverClass" value="org.postgresql.Driver"/>
+        <property name="serverName" value="${ENV=DB_HOST}"></property>
+        <property name="portNumber" value="${ENV=DB_PORT}"></property>
+        <property name="databaseName" value="${ENV=DB_NAME}"></property>
         <property name="User" value="${ENV=PG_USER}"></property>
+        <property name="Password" value="${ENV=PG_PASSWORD}"></property>
 		<property name="CurrentSchema" value="fmd"></property>
     </jdbc-connection-pool>
     <jdbc-connection-pool is-isolation-level-guaranteed="false" datasource-classname="org.postgresql.ds.PGSimpleDataSource" name="FMDB-DB-External_Proxy_user" sql-trace-listeners="" res-type="javax.sql.DataSource">
-         <property name="URL" value="${ENV=JDBC_SETTING}"></property>
-        <property name="Password" value="${ENV=PG_PASSWORD}"></property>
-		<property name="driverClass" value="org.postgresql.Driver"/>
+        <property name="serverName" value="${ENV=DB_HOST}"></property>
+        <property name="portNumber" value="${ENV=DB_PORT}"></property>
+        <property name="databaseName" value="${ENV=DB_NAME}"></property>
         <property name="User" value="${ENV=PG_USER}"></property>
+        <property name="Password" value="${ENV=PG_PASSWORD}"></property>
 		<property name="CurrentSchema" value="fmd"></property>
     </jdbc-connection-pool>
     


### PR DESCRIPTION
- encountered the following [issue](https://github.com/payara/Payara/issues/4864)
- updated glassfish-resources.xml to use database url components instead of database url parameter
- application was failing to start with the following error: ```shell Internal Exception: java.sql.SQLException: Error in allocating a connection. Cause: Access denied to execute this method : setURL ```